### PR TITLE
Update FLAME GPU 2 from 2.0.0-rc to 2.0.0-rc.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.18...3.25 FATAL_ERROR)
 
 # Optionaly set the version of flamegpu which should be used, ideally a tag (i.e. `v2.0.0-rc`) or branch name, or potentially a commit hash.
-set(FLAMEGPU_VERSION "v2.0.0-rc" CACHE STRING "FLAMEGPU/FLAMEGPU2 git branch or tag to use")
+set(FLAMEGPU_VERSION "v2.0.0-rc.1" CACHE STRING "FLAMEGPU/FLAMEGPU2 git branch or tag to use")
 # If the above version is a hash instead, also set FLAMEGPU_VERSION_ALLOW_HASH to ON
 # set(FLAMEGPU_VERSION_ALLOW_HASH "ON")
 


### PR DESCRIPTION
This brings in a number of bug fixes,
including a bug with a telemetry packet being emitted every time a submodel completed (FLAMEGPU/FLAMEGPU2#1079), which would impact the reported runtime significantly.
